### PR TITLE
Make @ipld/reviewers closed instead of secret

### DIFF
--- a/github/ipld/membership.json
+++ b/github/ipld/membership.json
@@ -146,9 +146,6 @@
   "momack2": {
     "role": "member"
   },
-  "mvdan": {
-    "role": "member"
-  },
   "mxinden": {
     "role": "member"
   },

--- a/github/ipld/repository.json
+++ b/github/ipld/repository.json
@@ -42,6 +42,7 @@
   "js-dag-cbor": {},
   "js-dag-json": {},
   "js-dag-pb": {},
+  "js-dag-ucan": {},
   "js-datastore-car": {},
   "js-examples": {},
   "js-fbl": {},

--- a/github/ipld/repository_collaborator.json
+++ b/github/ipld/repository_collaborator.json
@@ -34,10 +34,10 @@
     }
   },
   "explore.ipld.io": {
-    "andyschwab": {
+    "alvin-reyes": {
       "permission": "push"
     },
-    "davidd8": {
+    "andyschwab": {
       "permission": "push"
     },
     "lidel": {
@@ -285,6 +285,14 @@
   "js-dag-pb": {
     "web3-bot": {
       "permission": "push"
+    }
+  },
+  "js-dag-ucan": {
+    "Gozala": {
+      "permission": "admin"
+    },
+    "hugomrdias": {
+      "permission": "maintain"
     }
   },
   "js-datastore-car": {

--- a/github/ipld/team.json
+++ b/github/ipld/team.json
@@ -72,7 +72,7 @@
   "reviewers": {
     "id": "5943802",
     "parent_team_id": null,
-    "privacy": "secret"
+    "privacy": "closed"
   },
   "w3dt-stewards": {
     "id": "4657014",

--- a/github/ipld/team.json
+++ b/github/ipld/team.json
@@ -1,65 +1,82 @@
 {
   "Admin": {
     "id": "2080485",
-    "parent_team_id": null
+    "parent_team_id": null,
+    "privacy": "closed"
   },
   "Contributors": {
     "id": "2411284",
-    "parent_team_id": null
+    "parent_team_id": null,
+    "privacy": "closed"
   },
   "Core": {
     "id": "3403997",
-    "parent_team_id": null
+    "parent_team_id": null,
+    "privacy": "closed"
   },
   "DX": {
     "id": "2827046",
-    "parent_team_id": null
+    "parent_team_id": null,
+    "privacy": "closed"
   },
   "Go Team": {
     "id": "2411285",
-    "parent_team_id": null
+    "parent_team_id": null,
+    "privacy": "closed"
   },
   "Infra": {
     "id": "3140142",
-    "parent_team_id": null
+    "parent_team_id": null,
+    "privacy": "closed"
   },
   "Java Team": {
     "id": "2211157",
-    "parent_team_id": null
+    "parent_team_id": null,
+    "privacy": "closed"
   },
   "JavaScript Team": {
     "id": "2208929",
-    "parent_team_id": null
+    "parent_team_id": null,
+    "privacy": "closed"
   },
   "Python Team": {
     "id": "2474599",
-    "parent_team_id": null
+    "parent_team_id": null,
+    "privacy": "closed"
   },
   "Rust Team": {
     "id": "2598323",
-    "parent_team_id": null
+    "parent_team_id": null,
+    "privacy": "closed"
   },
   "Swift Team": {
     "id": "2568968",
-    "parent_team_id": null
+    "parent_team_id": null,
+    "privacy": "closed"
   },
   "ci": {
     "id": "2562367",
-    "parent_team_id": null
+    "parent_team_id": null,
+    "privacy": "closed"
   },
   "close-collaborators": {
     "id": "5714572",
-    "parent_team_id": null
+    "parent_team_id": null,
+    "privacy": "closed"
   },
   "research": {
     "id": "2591269",
-    "parent_team_id": null
+    "parent_team_id": null,
+    "privacy": "closed"
+  },
+  "reviewers": {
+    "id": "5943802",
+    "parent_team_id": null,
+    "privacy": "secret"
   },
   "w3dt-stewards": {
     "id": "4657014",
-    "parent_team_id": null
-  },
-  "reviewers": {
-    "parent_team_id": null
+    "parent_team_id": null,
+    "privacy": "closed"
   }
 }

--- a/github/ipld/team_membership.json
+++ b/github/ipld/team_membership.json
@@ -76,9 +76,6 @@
     "mikeal": {
       "role": "maintainer"
     },
-    "mvdan": {
-      "role": "member"
-    },
     "rvagg": {
       "role": "maintainer"
     },
@@ -141,9 +138,6 @@
       "role": "member"
     },
     "momack2": {
-      "role": "member"
-    },
-    "mvdan": {
       "role": "member"
     },
     "petar": {
@@ -319,6 +313,23 @@
       "role": "maintainer"
     }
   },
+  "reviewers": {
+    "BigLep": {
+      "role": "member"
+    },
+    "RangerMauve": {
+      "role": "member"
+    },
+    "rvagg": {
+      "role": "maintainer"
+    },
+    "warpfork": {
+      "role": "maintainer"
+    },
+    "willscott": {
+      "role": "member"
+    }
+  },
   "w3dt-stewards": {
     "BigLep": {
       "role": "maintainer"
@@ -338,12 +349,5 @@
     "lidel": {
       "role": "member"
     }
-  },
-  "reviewers": {
-    "rvagg": {"role": "member"},
-    "BigLep": {"role": "member"},
-    "warpfork": {"role": "member"},
-    "RangerMauve": {"role": "member"},
-    "willscott": {"role": "member"}
   }
 }

--- a/github/ipld/team_repository.json
+++ b/github/ipld/team_repository.json
@@ -398,11 +398,6 @@
       "permission": "pull"
     }
   },
-  "DX": {
-    "explore.ipld.io": {
-      "permission": "push"
-    }
-  },
   "Go Team": {
     "cid-cbor": {
       "permission": "pull"

--- a/terraform/resources_override.tf
+++ b/terraform/resources_override.tf
@@ -33,7 +33,7 @@ resource "github_team" "this" {
       members_count,
       node_id,
       # parent_team_id,
-      privacy,
+      # privacy,
       slug
     ]
   }


### PR DESCRIPTION
[Why was reviewers team secret in the first place?](https://github.com/ipld/ipld/issues/193#issuecomment-1103289317)

The default value for team privacy is `secret`. See https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team#argument-reference

It was not set in https://github.com/ipld/github-mgmt/pull/2 so the default was used.

To be able to modify `privacy` on existing teams through GitHub Management I:
- told GitHub Management to stop ignoring changes to `team.privacy` https://github.com/ipld/github-mgmt/commit/e9217dced9b30b3e95502098a9b41df96fe0920e
- ran `Sync` workflow which created https://github.com/ipld/github-mgmt/commit/d1b33c71e569c376ac6eb76b4d341ee0bc83d252
- modified the privacy value for reviewers in https://github.com/ipld/github-mgmt/commit/5cb9c98537e0900fe2a860e0cce2a995bbb0c417

[Why did reviewers not get id after the PR that added that team was merged?](https://github.com/ipld/ipld/issues/193#issuecomment-1103295828)

For that to happen, I (or other org admin) should have executed `Sync` workflow after the merge and I did not do it.

The `Sync` workflow should be really running on schedule - this is on our TODO list.

On top of that, we also plan for `parent_team_id` to accept not only team ID but also team name. Once that's implemented, the need to have `id` field present in JSON would diminish.



