### PR TITLE
Add IPLD repository to reviewers team

### DIFF
--- a/github/ipld/team_repository.json
+++ b/github/ipld/team_repository.json
@@ -702,6 +702,11 @@
       "permission": "admin"
     }
   },
+  "reviewers": {
+    "ipld": {
+      "permission": "maintain"
+    }
+  },
   "w3dt-stewards": {
     "auto": {
       "permission": "admin"


### PR DESCRIPTION
<!-- Please explain the reason for this change. -->

It should be possible to assign the reviewers team to review PRs for PRs to ipld/ipld

From what I can tell, it's necessary to have the team added to the team for them to show up in the autocomplete list.

Related to this discussion: https://github.com/ipld/ipld/issues/193#issuecomment-1108928393