### PR TITLE
Add go-ipld-prime to reviewers team

### DIFF
--- a/github/ipld/team_repository.json
+++ b/github/ipld/team_repository.json
@@ -705,6 +705,9 @@
   "reviewers": {
     "ipld": {
       "permission": "maintain"
+    },
+    "go-ipld-prime": {
+      "permission": "maintain"
     }
   },
   "w3dt-stewards": {


### PR DESCRIPTION
<!-- Please explain the reason for this change. -->

Per https://github.com/ipld/ipld/issues/193#issuecomment-1113792485 we'd like to have `@ipld/reviewers` available to be added as a reviewer for PRs and stuff for go-ipld-prime