### PR TITLE
Add w3dt-stewareds to go-car-priv

### DIFF
--- a/github/ipld/team_repository.json
+++ b/github/ipld/team_repository.json
@@ -726,6 +726,9 @@
     "go-car": {
       "permission": "admin"
     },
+    "go-car-priv": {
+      "permission": "admin"
+    },
     "go-codec-dagpb": {
       "permission": "admin"
     },


### PR DESCRIPTION
Enable PL EngRes Stewards to have access to the go-car-priv repository given their involvement with security events.
