### PR TITLE
chore: remove Jorropo from go-car-priv collaborators

### DIFF
--- a/github/ipld.yml
+++ b/github/ipld.yml
@@ -209,8 +209,6 @@ repositories:
     visibility: public
   go-car-priv:
     collaborators:
-      admin:
-        - Jorropo
       pull:
         - TippyFlitsUK
         - alvin-reyes


### PR DESCRIPTION
Being collaborator is redundant since Jorropo has higher access to `go-car-priv` through `w3dt-stewards` team membership.
