### PR TITLE
feat: do not allow destroying memberships and repositories through github-mgmt

### DIFF
--- a/terraform/resources.tf
+++ b/terraform/resources.tf
@@ -13,6 +13,7 @@ resource "github_membership" "this" {
 
   lifecycle {
     ignore_changes = []
+    prevent_destroy = true
   }
 }
 
@@ -70,6 +71,7 @@ resource "github_repository" "this" {
 
   lifecycle {
     ignore_changes = []
+    prevent_destroy = true
   }
 }
 


### PR DESCRIPTION
### Summary
`membership` and `repositories` are hard to restore. Additionally, it's never what we want to do. In case of memberships, we want to move people to alumni team instead. And in case of repositories, we want to archive them.

### Why do you need this?
To prevent incidents like this: https://github.com/ipld/github-mgmt/pull/40

### What else do we need to know?
<!-- any details required to complete the request? are there any special concerns to consider? priority, confidentiality, deadlines, etc -->

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
