### PR TITLE
chore: add ipfs-gui team

### DIFF
--- a/github/ipld.yml
+++ b/github/ipld.yml
@@ -32,6 +32,7 @@ members:
     - davidd8
     - dhruvbaldawa
     - dirkmc
+    - djmcquillan
     - flyingzumwalt
     - Gozala
     - guseggert
@@ -46,6 +47,7 @@ members:
     - jbenetsafer
     - jesseclay
     - Jorropo
+    - juliaxbow
     - kevina
     - Kubuxu
     - kumavis
@@ -69,12 +71,15 @@ members:
     - ribasushi
     - RichardLitt
     - richardschneider
+    - sgtpooki
     - tchardin
+    - tinytb
     - travisperson
     - vasco-santos
     - victorb
     - wanderer
     - web3-bot
+    - whizzzkid
     - willscott
 repositories:
   auto:

--- a/github/ipld.yml
+++ b/github/ipld.yml
@@ -1832,7 +1832,6 @@ teams:
         - juliaxbow
         - lidel
         - olizilla
-        - sgtpooki
         - whizzzkid
     privacy: closed
   Java Team:

--- a/github/ipld.yml
+++ b/github/ipld.yml
@@ -1815,6 +1815,21 @@ teams:
         - laurentsenta
     parent_team_id: w3dt-stewards
     privacy: closed
+  ipfs-gui:
+    members:
+      maintainer:
+        - sgtpooki
+        - rvagg
+        - tinytb
+      member:
+        - sgtpooki
+        - lidel
+        - hacdias
+        - olizilla
+        - whizzzkid
+        - djmcquillan
+        - juliaxbow
+    privacy: closed
   Java Team:
     description: Java Java Java Java
     members:
@@ -1917,3 +1932,4 @@ teams:
         - laurentsenta
         - lidel
     privacy: closed
+  

--- a/github/ipld.yml
+++ b/github/ipld.yml
@@ -1818,17 +1818,17 @@ teams:
   ipfs-gui:
     members:
       maintainer:
-        - sgtpooki
         - rvagg
+        - sgtpooki
         - tinytb
       member:
-        - sgtpooki
-        - lidel
-        - hacdias
-        - olizilla
-        - whizzzkid
         - djmcquillan
+        - hacdias
         - juliaxbow
+        - lidel
+        - olizilla
+        - sgtpooki
+        - whizzzkid
     privacy: closed
   Java Team:
     description: Java Java Java Java
@@ -1932,4 +1932,3 @@ teams:
         - laurentsenta
         - lidel
     privacy: closed
-  


### PR DESCRIPTION
### Summary
Adding ipfs-gui team in the ipld org.

See discussion at https://github.com/ipld/explore.ipld.io/pull/95

### Why do you need this?

ipfs-gui (IPFS Ignite team) maintains ipld/explore.ipld.io

### What else do we need to know?
<!-- any details required to complete the request? are there any special concerns to consider? priority, confidentiality, deadlines, etc -->
N/A

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [x] It is clear where the request is coming from (if unsure, ask)
- [x] All the automated checks passed
- [x] The YAML changes reflect the summary of the request
- [x] The Terraform plan posted as a comment reflects the summary of the request
