### PR TITLE
manage go-trustless-utils

### DIFF
--- a/github/ipld.yml
+++ b/github/ipld.yml
@@ -868,6 +868,8 @@ repositories:
         require_signed_commits: false
         required_linear_history: true
     collaborators:
+      admin:
+        - rvagg
       push:
         - web3-bot
     default_branch: master
@@ -880,6 +882,9 @@ repositories:
     squash_merge_commit_message: COMMIT_MESSAGES
     squash_merge_commit_title: COMMIT_OR_PR_TITLE
     visibility: public
+    teams:
+      push:
+        - Go Team
   go-walker:
     advanced_security: false
     allow_update_branch: false

--- a/github/ipld.yml
+++ b/github/ipld.yml
@@ -881,10 +881,10 @@ repositories:
     secret_scanning: true
     squash_merge_commit_message: COMMIT_MESSAGES
     squash_merge_commit_title: COMMIT_OR_PR_TITLE
-    visibility: public
     teams:
       push:
         - Go Team
+    visibility: public
   go-walker:
     advanced_security: false
     allow_update_branch: false


### PR DESCRIPTION
main aim here is to give @hannahhoward access to go-trustless-utils which I think this does via `Go Team`