### PR TITLE
WIP: Remove inactive members, collaborators and teams

### DIFF
--- a/github/ipld.yml
+++ b/github/ipld.yml
@@ -10,13 +10,6 @@ members:
     - galargh
     - vmx
   member:
-    - daviddias
-    - dignifiedquire
-    - jbenet
-    - marten-seemann
-    - Stebalien
-    - warpfork
-    - whyrusleeping
     - 0xDanomite
     - aarshkshah1992
     - achingbrain
@@ -32,7 +25,9 @@ members:
     - cloutiertyler
     - davidad
     - davidd8
+    - daviddias
     - dhruvbaldawa
+    - dignifiedquire
     - dirkmc
     - flyingzumwalt
     - Gozala
@@ -45,6 +40,7 @@ members:
     - ipfsbot
     - ipldbot
     - jacobheun
+    - jbenet
     - jbenetsafer
     - jesseclay
     - Jorropo
@@ -57,6 +53,7 @@ members:
     - litzenberger
     - magik6k
     - MarcoPolo
+    - marten-seemann
     - masih
     - mcollina
     - michaelavila
@@ -73,14 +70,17 @@ members:
     - RichardLitt
     - richardschneider
     - SgtPooki
+    - Stebalien
     - tchardin
     - tinytb
     - travisperson
     - vasco-santos
     - victorb
     - wanderer
+    - warpfork
     - web3-bot
     - whizzzkid
+    - whyrusleeping
     - willscott
 repositories:
   auto:

--- a/github/ipld.yml
+++ b/github/ipld.yml
@@ -2,12 +2,15 @@
 
 members:
   admin:
-    # Admin permissions are intentionally minimal. 
+    # Admin permissions map to "org admin" permissions listed in 
+    # https://docs.github.com/en/organizations/managing-peoples-access-to-your-organization-with-roles/roles-in-an-organization#permissions-for-organization-rolesare 
+    # These permissions are very broad, and the thus the list of people is intentionally minimal. 
     # Permissoins are distributed across 3-4 separate organizations.
-    # One can request additional permissions using ipld/github-mgmt.
+    # One can request additional permissions for specific repos using ipld/github-mgmt.
     - andyschwab-admin
     - aschmahmann
     - galargh
+    - rvagg
     - vmx
   member:
     - 0xDanomite

--- a/github/ipld.yml
+++ b/github/ipld.yml
@@ -110,9 +110,6 @@ repositories:
     advanced_security: false
     allow_update_branch: false
     archived: false
-    collaborators:
-      admin:
-        - vmx
     default_branch: master
     description: Spec for Content Identifiers (CIDs) in CBOR for IANA CBOR Tag registry
     has_discussions: false
@@ -214,8 +211,6 @@ repositories:
     allow_update_branch: false
     archived: false
     collaborators:
-      admin:
-        - petar
       push:
         - web3-bot
     default_branch: main
@@ -262,15 +257,6 @@ repositories:
     advanced_security: false
     allow_update_branch: false
     archived: false
-    collaborators:
-      admin:
-        - lidel
-        - olizilla
-      maintain:
-        - hacdias
-      push:
-        - alvin-reyes
-        - andyschwab
     default_branch: master
     description: Explore the Merkle Forest from the comfort of your browser
     has_discussions: false
@@ -378,13 +364,6 @@ repositories:
     advanced_security: false
     allow_update_branch: false
     archived: false
-    collaborators:
-      pull:
-        - alvin-reyes
-        - jennijuju
-        - TippyFlitsUK
-      push:
-        - hsanjuan
     default_branch: master
     description: go-car but private for hush-hush security stuff
     files:
@@ -441,7 +420,6 @@ repositories:
         - masih
         - willscott
       push:
-        - hannahhoward
         - web3-bot
     default_branch: master
     description: A content addressible archive utility
@@ -513,9 +491,6 @@ repositories:
     advanced_security: false
     allow_update_branch: false
     archived: false
-    collaborators:
-      push:
-        - dustmop
     default_branch: master
     description: Use IPLD from Starlark -- read and write data, and play
       programmagically in an interpreted language!
@@ -554,8 +529,6 @@ repositories:
     allow_update_branch: false
     archived: false
     collaborators:
-      admin:
-        - warpfork
       push:
         - web3-bot
     default_branch: master
@@ -580,8 +553,6 @@ repositories:
     allow_update_branch: false
     archived: false
     collaborators:
-      admin:
-        - marten-seemann
       push:
         - web3-bot
     default_branch: master
@@ -627,8 +598,6 @@ repositories:
     allow_update_branch: false
     archived: false
     collaborators:
-      admin:
-        - willscott
       push:
         - web3-bot
     default_branch: master
@@ -696,8 +665,6 @@ repositories:
         required_status_checks:
           strict: true
     collaborators:
-      admin:
-        - warpfork
       push:
         - hannahhoward
         - web3-bot
@@ -757,7 +724,6 @@ repositories:
     archived: false
     collaborators:
       push:
-        - ribasushi
         - web3-bot
     default_branch: master
     has_discussions: false
@@ -823,9 +789,6 @@ repositories:
     advanced_security: false
     allow_update_branch: false
     archived: false
-    collaborators:
-      admin:
-        - hannahhoward
     default_branch: main
     description: A simple store to record selector traversals
     has_discussions: false
@@ -856,12 +819,7 @@ repositories:
           required_approving_review_count: 1
           restrict_dismissals: false
     collaborators:
-      admin:
-        - adlrocha
-        - gammazero
-        - willscott
       push:
-        - ischasny
         - web3-bot
     default_branch: master
     description: Storage for hashes, targeted at content addressable systems
@@ -915,9 +873,6 @@ repositories:
     advanced_security: false
     allow_update_branch: false
     archived: false
-    collaborators:
-      admin:
-        - hannahhoward
     default_branch: main
     description: Walker provides an alternate, parellizable and controllable way to
       execute selectors
@@ -1071,10 +1026,6 @@ repositories:
     advanced_security: false
     allow_update_branch: false
     archived: false
-    collaborators:
-      maintain:
-        - olizilla
-        - salmad3
     default_branch: master
     description: InterPlanetary Linked Data
     has_discussions: false
@@ -1133,8 +1084,6 @@ repositories:
     collaborators:
       admin:
         - ianopolous
-      push:
-        - kevodwyer
     default_branch: master
     description: Java implementation of Content Identifier
     files:
@@ -1163,9 +1112,6 @@ repositories:
     advanced_security: false
     allow_update_branch: false
     archived: false
-    collaborators:
-      push:
-        - ianopolous
     default_branch: master
     description: A Java implementation of the IPLD cbor format
     has_discussions: false
@@ -1237,9 +1183,6 @@ repositories:
     advanced_security: false
     allow_update_branch: false
     archived: false
-    collaborators:
-      admin:
-        - achingbrain
     default_branch: master
     description: Convert a BlockCodec from the multiformats module to an IPLD format
     has_discussions: false
@@ -1438,11 +1381,6 @@ repositories:
     collaborators:
       admin:
         - Gozala
-      maintain:
-        - alanshaw
-        - gobengo
-        - hugomrdias
-        - olizilla
     default_branch: main
     description: UCAN codec for IPLD
     files:
@@ -2188,9 +2126,6 @@ repositories:
     advanced_security: false
     allow_update_branch: false
     archived: false
-    collaborators:
-      admin:
-        - achingbrain
     default_branch: master
     description: Converts an IPLD Format into a BlockCodec for use with the
       multiformats module
@@ -2635,9 +2570,6 @@ repositories:
       admin:
         - alanshaw
         - Gozala
-        - hugomrdias
-      maintain:
-        - gobengo
     default_branch: main
     description: UnixFS Directed Acyclic Graph for IPLD
     files:
@@ -2707,10 +2639,6 @@ repositories:
     collaborators:
       admin:
         - Stebalien
-      push:
-        - dvc94ch
-        - lKrayola
-        - molekilla
     default_branch: master
     description: Rust IPLD library
     files:
@@ -3051,9 +2979,6 @@ repositories:
           restrict_dismissals: false
         required_status_checks:
           strict: true
-    collaborators:
-      admin:
-        - aschmahmann
     default_branch: main
     description: Tools and examples of IPLD codecs and ADLs in WASM callable from hosts
     files:
@@ -3105,48 +3030,77 @@ teams:
   Admin:
     members:
       maintainer:
-        - aschmahmann
-        - daviddias
-        - jbenet
-        - Stebalien
         - vmx
-        - warpfork
-        - whyrusleeping
-      member:
-        - BigLep
-        - Kubuxu
     privacy: closed
   Alumni:
-    privacy: closed
-  ci:
-    description: ci
     members:
       member:
+        - 0xDanomite
+        - aarshkshah1992
+        - AdamStone
+        - adlrocha
+        - ajnavarro
+        - andrew
+        - andyschwab-admin
+        - andyschwab
+        - anorth
+        - arajasek
+        - aschmahmann
+        - cloutiertyler
+        - davidad
+        - davidd8
+        - daviddias
+        - dhruvbaldawa
+        - dignifiedquire
+        - dirkmc
+        - flyingzumwalt
+        - guseggert
+        - haadcode
+        - hacdias
+        - hugomrdias
         - ipfsbot
-    privacy: closed
-  close-collaborators:
-    description: Folks who work across many IPLD repos and languages
-    members:
-      maintainer:
-        - warpfork
-      member:
+        - ipldbot
+        - jacobheun
+        - jbenet
+        - jbenetsafer
+        - jesseclay
+        - Jorropo
+        - juliaxbow
+        - kevina
+        - Kubuxu
+        - kumavis
+        - lidel
+        - litzenberger
+        - magik6k
+        - MarcoPolo
+        - marten-seemann
+        - mcollina
+        - michaelavila
+        - miyazono
+        - momack2
+        - mxinden
+        - nicola
+        - petar
+        - pkafei
         - RangerMauve
+        - raulk
+        - ribasushi
+        - RichardLitt
+        - richardschneider
+        - tchardin
+        - tinytb
+        - travisperson
+        - vasco-santos
+        - victorb
+        - wanderer
+        - warpfork
+        - whizzzkid
+        - whyrusleeping
     privacy: closed
   Contributors:
     members:
       maintainer:
-        - aschmahmann
-        - daviddias
-        - Stebalien
         - vmx
-        - whyrusleeping
-      member:
-        - adlrocha
-        - davidad
-        - flyingzumwalt
-        - Kubuxu
-        - nicola
-        - RichardLitt
     privacy: closed
   Core:
     description: Core Team
@@ -3155,17 +3109,9 @@ teams:
         - rvagg
         - Stebalien
         - vmx
-        - warpfork
       member:
         - BigLep
         - willscott
-    privacy: closed
-  DX:
-    description: Developer Experience Team
-    members:
-      member:
-        - travisperson
-        - victorb
     privacy: closed
   github-mgmt stewards:
     # NOTE: created to capture users with push+ access to github-mgmt repository
@@ -3177,42 +3123,16 @@ teams:
       #  - be familiar with GitHub Management
       #  - be ready to triage/review org configuration change request in github-mgmt
       maintainer:
-        - aschmahmann
         - rvagg
-      member:
-        - BigLep
-        - lidel
-        - willscott
     privacy: closed
   Go Team:
     members:
       maintainer:
-        - aschmahmann
         - rvagg
-        - Stebalien
-        - warpfork
-        - whyrusleeping
       member:
-        - aarshkshah1992
-        - anorth
-        - arajasek
-        - davidd8
-        - dirkmc
-        - guseggert
         - hannahhoward
-        - ipldbot
-        - Kubuxu
-        - magik6k
         - masih
-        - momack2
-        - petar
-        - raulk
-        - ribasushi
-        - tchardin
         - willscott
-    privacy: closed
-  Infra:
-    description: https://github.com/protocol/infra-team/
     privacy: closed
   ipdx:
     members:
@@ -3226,108 +3146,41 @@ teams:
       maintainer:
         - rvagg
         - SgtPooki
-      member:
-        - hacdias
-        - lidel
-        - olizilla
-        - whizzzkid
-    privacy: closed
-  Java Team:
-    description: Java Java Java Java
-    members:
-      maintainer:
-        - jbenet
-      member:
-        - ianopolous
     privacy: closed
   JavaScript Team:
     description: The most awesome team
     members:
       maintainer:
-        - daviddias
-        - dignifiedquire
         - rvagg
         - vmx
       member:
         - achingbrain
-        - AdamStone
         - alanshaw
-        - Gozala
-        - haadcode
-        - hacdias
-        - hugomrdias
-        - ipldbot
-        - kumavis
-        - litzenberger
-        - magik6k
-        - mcollina
-        - momack2
-        - nicola
         - olizilla
-        - pkafei
-        - richardschneider
-        - tchardin
-        - vasco-santos
-        - victorb
-        - wanderer
-    privacy: closed
-  Python Team:
-    description: Snaaaaakes 🐍
-    members:
-      maintainer:
-        - daviddias
-      member:
-        - dhruvbaldawa
     privacy: closed
   research:
     members:
       maintainer:
-        - dignifiedquire
-        - jbenet
-        - miyazono
-        - nicola
-        - Stebalien
         - vmx
-      member:
-        - davidad
     privacy: closed
   reviewers:
     members:
       maintainer:
         - rvagg
-        - warpfork
       member:
         - BigLep
-        - RangerMauve
         - willscott
     privacy: closed
   Rust Team:
     members:
       maintainer:
         - vmx
-      member:
-        - adlrocha
-        - MarcoPolo
-        - mxinden
-    privacy: closed
-  Swift Team:
-    members:
-      maintainer:
-        - daviddias
-      member:
-        - cloutiertyler
     privacy: closed
   w3dt-stewards:
     members:
       maintainer:
-        - aschmahmann
         - BigLep
-        - Stebalien
       member:
         - achingbrain
         - galargh
-        - guseggert
-        - Jorropo
-        - laurentsenta
-        - lidel
     privacy: closed

--- a/github/ipld.yml
+++ b/github/ipld.yml
@@ -2,19 +2,21 @@
 
 members:
   admin:
+    # Admin permissions are intentionally minimal. 
+    # Permissoins are distributed across 3-4 separate organizations.
+    # One can request additional permissions using ipld/github-mgmt.
     - andyschwab-admin
     - aschmahmann
+    - galargh
+    - vmx
+  member:
     - daviddias
     - dignifiedquire
-    - galargh
     - jbenet
     - marten-seemann
-    - rvagg
     - Stebalien
-    - vmx
     - warpfork
     - whyrusleeping
-  member:
     - 0xDanomite
     - aarshkshah1992
     - achingbrain

--- a/notes/2024-02-06 biglep feedback for PR #65.md
+++ b/notes/2024-02-06 biglep feedback for PR #65.md
@@ -15,8 +15,9 @@ Below are links or lookups I wish more readily available when engaging with gith
 I find myself looking them up each time I'm thinking about github-mgmt.  
 I didn't see them in https://github.com/ipld/github-mgmt/tree/master/docs.  
 
+* Org-level permissions: https://docs.github.com/en/organizations/managing-peoples-access-to-your-organization-with-roles/roles-in-an-organization#permissions-for-organization-roles
 * Org base permissions: https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/setting-base-permissions-for-an-organization#setting-base-permissions
-* Permissions for each role: https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/repository-roles-for-an-organization#permissions-for-each-role 
+* Permissions for each repository role: https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/repository-roles-for-an-organization#permissions-for-each-role 
 * Difference between team maintainer vs. member: https://docs.github.com/en/organizations/organizing-members-into-teams/assigning-the-team-maintainer-role-to-a-team-member
 
 Reminders I wish were more present:
@@ -88,8 +89,8 @@ If some of the feedback above is incorporated, I'm wondering if we should do com
 # IPLD specifics
 ## Org admins
 At the minimum, this should be reduced to just a few.  I made a commit as a first pass: https://github.com/ipld/github-mgmt/pull/65/commits/5d21c43365e48ab589628e8b25188a70e443b8ad
-I wonder if we should go further by reduce the org owners to zero, and rely on escalation via github-mgmt in the rare cases where this is needed?
-(Or maybe org admin/owner permsissions is needed periodically to approve integrations, get Github emails targeted at admins, etc?  If that's the case, then just leaving it to a few people makes sense.)
+I wondered if we should go further by reduce the org owners to zero, and rely on escalation via github-mgmt in the rare cases where this is needed?
+It looks like it's encouraged that we just have a few per https://docs.github.com/en/organizations/managing-peoples-access-to-your-organization-with-roles/roles-in-an-organization#organization-owners, so maybe the current proposal in the PR is good.
 
 ## Base permission
 ✅ We look to be at "no permissions" which I agree is best to do to keep things clear and easy to reason about.  One's permissions have to be increased from nothing based on what's in github-mgmt. 

--- a/notes/2024-02-06 biglep feedback for PR #65.md
+++ b/notes/2024-02-06 biglep feedback for PR #65.md
@@ -22,6 +22,7 @@ I didn't see them in https://github.com/ipld/github-mgmt/tree/master/docs.
 Reminders I wish were more present:
 * Terraform “push” corresponds with Github “write”.
 * Terraform “pull” corresponds with Github “read”.
+* Terraform members.admin correspond with Github "org owner" per https://registry.terraform.io/providers/integrations/github/latest/docs/resources/membership
 
 ## User-oriented view of changes
 I came at this again independently, but I would like something like was expressed in https://github.com/libp2p/github-mgmt/pull/12#pullrequestreview-999621620.

--- a/notes/2024-02-06 biglep feedback for PR #65.md
+++ b/notes/2024-02-06 biglep feedback for PR #65.md
@@ -1,0 +1,97 @@
+# Purpose
+This is intended to accompany https://github.com/ipld/github-mgmt/pull/65.
+I did it as its own file to enable threaded replies on specific lines/sections of this file with the PR UI.
+If I didn't do this, we'd be limited to quote replies in https://github.com/ipld/github-mgmt/pull/65.
+Given that I expect a decent amount of back-and-forth on some of these suggestions, I figured quote replies would get unweildy.
+I'm not assuming this file will get checked in.  It's purely to help with the code review process.
+Maybe at the end if there is useful content here, we copy/paste it into the PR itself.  (Alternatively we could merge it in.)
+Or I guess we could just move into Github discussions?  (I didn't do that because wanted to keep all the context here.)
+Obivously I could have done this in another tool like Google Docs, but I wanted to keep the discussion more open and discoverable (especially since this will the basis for changes to libp2p, ipfs, etc. repos).
+If I should do something else, please let me know!
+
+# General github-mgmt feedback/wishes
+## Documentation I wish was more readily accessible when using github-mgmt
+Below are links or lookups I wish more readily available when engaging with github-mgmt.  
+I find myself looking them up each time I'm thinking about github-mgmt.  
+I didn't see them in https://github.com/ipld/github-mgmt/tree/master/docs.  
+
+* Org base permissions: https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/setting-base-permissions-for-an-organization#setting-base-permissions
+* Permissions for each role: https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/repository-roles-for-an-organization#permissions-for-each-role 
+* Difference between team maintainer vs. member: https://docs.github.com/en/organizations/organizing-members-into-teams/assigning-the-team-maintainer-role-to-a-team-member
+
+Reminders I wish were more present:
+* Terraform “push” corresponds with Github “write”.
+* Terraform “pull” corresponds with Github “read”.
+
+## User-oriented view of changes
+I came at this again independently, but I would like something like was expressed in https://github.com/libp2p/github-mgmt/pull/12#pullrequestreview-999621620.
+
+I think we should have some tooling that answers: "after these changes, what repos do I have permissions for, what permissions do I have, and why (because part of a team, or direct repo)".
+
+At the minimum, when we tag users we need to make clear that just because they’re tagged, that doesn’t mean that they are removed from the org.  
+Their access to certain repos / teams is what is being changed.  People need to look at the diff to see specifically.
+https://github.com/libp2p/github-mgmt/pull/12#pullrequestreview-999621620 speaks to how there was confusion when folks were @mentioned and that they thought they were being removed from the org.
+
+Even if we don't give the full user-oriented view of one's permissions, it would be great if we gave a user-oriented summary of the changes.  Example:
+
+```
+@biglep
+Removed from repos: repoName1/permissoinLevel1, repoName2/permissoinLevel2
+Removed from teams: team1
+```
+
+That by itself will cut down on some of the confusion, but it will still need a disclaimer (e.g., "Even though your direct repo permissions have been removed, you may still have access through a team.  Please check the full diff.").
+
+## More intelligent sorting of keys
+I wish github-mgmt didn’t sort all key alphabetically when there is a more meaningful default.  
+For example, with "collaborators” and “teams”, I want the keys be in descencing order: admin > maintain > push > triage > pull.
+Similarly, I want crucial properties like "archived" to be at the top.
+I think the default otherwise can be alphabetical.
+(Implementation wise I assume we do a custom sort function that pulls out any specific keys, sorts by that specified order, puts those first, and then adds the rest of the keys alphabetically.)
+
+# Somewhere between general and IPLD-specific
+These are at least things that apply to the 2024Q1 cleanup for ipld, libp2p, and ipfs orgs. Some of them can be generalized.
+
+## Archived repos cause clutter
+These .yaml files can be unwieldy.  One thing I think could help would be to have a view on all the repos that aren't archived.  Some ideas (I assume from least to most amount of work):
+* Put all the archived repos at the bottom of the file.  (I still don't like this one as much because archived repos will show up when doing text search for "team X" when trying to answer "what teams does X have permissions to").
+* Have an optional separate .yaml that merges in at build/process time.  This would allow a dedicated separate file (e.g., archived_repos.yaml).
+  * Generalizing this, maybe github-mgmt can be configured to do a merge of any specified files, which lets repo organizers decide if/how they want to break up their yaml file in general?
+* Go the IPFS route and actually have an "ipfs-inactive" org.  Archived projects can get moved there.  This makes things very clear about the maintenance status and also solves the declutter problem. 
+
+## Strip out access permissions to archived repos
+It adds clutter having individuals and teams showing up with access permissions in archived repos.  
+If a repo is archived, I think we should strip permissions.  
+Someone can always unarchive and add permissions through github-mgmt.  
+In addition to this reducing clutter, I this proposed process is good because it gives clear visibility to a significant repo event (e.g., unarchiving).
+
+## Remove the w3dt-stewards team
+That is legacy both in terms of name and function.
+It was used when there was a small team who was charged with looking after the whole github org and they didn't have github-mgmt at their disposal.
+In PLv10 / PL Innovation Network era, there is no corrolary for this.
+If broad action is needed, it can be done broadly via github-mgmt.  And where it can't be done directly with github-mgmt, github-mgmt can at least be done to give broad permissions to go do the broad action.
+
+## Default access of the ipdx team
+It looks like the ipdx team has admin permissions on most repos.   
+Should we maybe reduce this and instead ensure they just have github-mgmt admin access, which still enables them to "break glass" and escalate their access when needed?
+
+## Commit/PR order
+If some of the feedback above is incorporated, I'm wondering if we should do commits or PRs in this order to help make the consequential changes more clear.
+1. Remove access permissions of users/teams to archived reports.
+2. Factor out archived repos.
+3. Remove teams like w3dt-stewards
+4. Reduce ipdx access
+5. (Anything related to renaming team names)
+6. Other changes that the IPDX scripts picks up based on audit log inactivity and based on additional manual changes.  (This is the diff we need people to be scrutinizing.)
+
+# IPLD specifics
+## Org admins
+At the minimum, this should be reduced to just a few.  I made a commit as a first pass: https://github.com/ipld/github-mgmt/pull/65/commits/5d21c43365e48ab589628e8b25188a70e443b8ad
+I wonder if we should go further by reduce the org owners to zero, and rely on escalation via github-mgmt in the rare cases where this is needed?
+(Or maybe org admin/owner permsissions is needed periodically to approve integrations, get Github emails targeted at admins, etc?  If that's the case, then just leaving it to a few people makes sense.)
+
+## Base permission
+✅ We look to be at "no permissions" which I agree is best to do to keep things clear and easy to reason about.  One's permissions have to be increased from nothing based on what's in github-mgmt. 
+
+## Alumni Team
+✅ I agree we want this.  Great to see the script automatically populating it.


### PR DESCRIPTION
### ⚠️ Read first
This is in draft and hasn't been reviewed and shouldn't be taken as truth yet. This PR is a starting place so we can start framing the discussion around doing permission cleanup. There is also a corresponding FIL Slack channel #ip-stack-github-permissions-cleanup-2024q1

The current PR is what results from a [base script that IPDX has](https://github.com/ipld/github-mgmt/blob/master/scripts/src/actions/remove-inactive-members.ts#L41). @mentions will go out with who is affected when it's ready to be looked at.

Also note that 2024Q1 permissions cleanup is starting with ipld, but we (@galargh, @BigLep) intend to take the learnings/process to libp2p and ipfs orgs afterwards.

### Summary
<!-- include a short summary of the request -->

### Why do you need this?
<!-- include information here which is helpful toward engineers making independent decisions without stakeholders. simple requests may ignore this section, but more complex request should consider what might need to be known in advance and add it -->

### What else do we need to know?
<!-- any details required to complete the request? are there any special concerns to consider? priority, confidentiality, deadlines, etc -->

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
