### PR TITLE
Archive unused repos

### DIFF
--- a/github/ipld.yml
+++ b/github/ipld.yml
@@ -211,7 +211,7 @@ repositories:
   edelweiss:
     advanced_security: false
     allow_update_branch: false
-    archived: false
+    archived: true
     collaborators:
       push:
         - web3-bot
@@ -790,7 +790,7 @@ repositories:
   go-selector-store:
     advanced_security: false
     allow_update_branch: false
-    archived: false
+    archived: true
     default_branch: main
     description: A simple store to record selector traversals
     has_discussions: false
@@ -1184,7 +1184,7 @@ repositories:
   js-blockcodec-to-ipld-format:
     advanced_security: false
     allow_update_branch: false
-    archived: false
+    archived: true
     default_branch: master
     description: Convert a BlockCodec from the multiformats module to an IPLD format
     has_discussions: false
@@ -2127,7 +2127,7 @@ repositories:
   js-ipld-format-to-blockcodec:
     advanced_security: false
     allow_update_branch: false
-    archived: false
+    archived: true
     default_branch: master
     description: Converts an IPLD Format into a BlockCodec for use with the
       multiformats module


### PR DESCRIPTION
Noticed some repos that should probably be archived.

### Summary
The are some repos that no longer look to be used.  They were identified while going through https://github.com/ipld/github-mgmt/pull/65.  We my as well archive them to reduce clutter.

### Why do you need this?
Not needed, but it's for declutter.
It's also not a one-way door.  Repos can be unarchived if needed.

### What else do we need to know?
None

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
