### PR TITLE
Archive unused repos

### DIFF
--- a/github/ipld.yml
+++ b/github/ipld.yml
@@ -212,12 +212,8 @@ repositories:
   edelweiss:
     advanced_security: false
     allow_update_branch: false
-    archived: false
+    archived: true
     collaborators:
-      admin:
-        - petar
-      push:
-        - web3-bot
     default_branch: main
     description: Decentralized Protocol Compiler
     has_discussions: true
@@ -228,9 +224,6 @@ repositories:
     squash_merge_commit_message: COMMIT_MESSAGES
     squash_merge_commit_title: COMMIT_OR_PR_TITLE
     teams:
-      admin:
-        - ipdx
-        - w3dt-stewards
     visibility: public
   eth-hash-to-cid:
     advanced_security: false
@@ -822,10 +815,8 @@ repositories:
   go-selector-store:
     advanced_security: false
     allow_update_branch: false
-    archived: false
+    archived: true
     collaborators:
-      admin:
-        - hannahhoward
     default_branch: main
     description: A simple store to record selector traversals
     has_discussions: false
@@ -1236,10 +1227,8 @@ repositories:
   js-blockcodec-to-ipld-format:
     advanced_security: false
     allow_update_branch: false
-    archived: false
+    archived: true
     collaborators:
-      admin:
-        - achingbrain
     default_branch: master
     description: Convert a BlockCodec from the multiformats module to an IPLD format
     has_discussions: false
@@ -1250,9 +1239,6 @@ repositories:
     squash_merge_commit_message: COMMIT_MESSAGES
     squash_merge_commit_title: COMMIT_OR_PR_TITLE
     teams:
-      admin:
-        - ipdx
-        - w3dt-stewards
     visibility: public
   js-car:
     advanced_security: false
@@ -2187,10 +2173,8 @@ repositories:
   js-ipld-format-to-blockcodec:
     advanced_security: false
     allow_update_branch: false
-    archived: false
+    archived: true
     collaborators:
-      admin:
-        - achingbrain
     default_branch: master
     description: Converts an IPLD Format into a BlockCodec for use with the
       multiformats module
@@ -2202,9 +2186,6 @@ repositories:
     squash_merge_commit_message: COMMIT_MESSAGES
     squash_merge_commit_title: COMMIT_OR_PR_TITLE
     teams:
-      admin:
-        - ipdx
-        - w3dt-stewards
     visibility: public
   js-ipld-garbage:
     advanced_security: false


### PR DESCRIPTION
Noticed some repos that should probably be archived.

### Summary
The are some repos that no longer look to be used.  They were identified while going through https://github.com/ipld/github-mgmt/pull/65.  I acted in https://github.com/ipld/github-mgmt/pull/66, but want to apply this subset of changes to master and also remove permissions of the archived repos.

### Why do you need this?
Not needed, but it's for declutter.
It's also not a one-way door.  Repos can be unarchived if needed.

### What else do we need to know?
None

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
