### PR TITLE
Remove web3-bot from codec-fixtures

### DIFF
--- a/github/ipld.yml
+++ b/github/ipld.yml
@@ -130,9 +130,6 @@ repositories:
     advanced_security: false
     allow_update_branch: false
     archived: false
-    collaborators:
-      push:
-        - web3-bot
     default_branch: master
     description: Fixtures for testing standard IPLD codecs
     files:


### PR DESCRIPTION
turns out this is neither useful nor does it fully work on this repo, so we'll just exclude it
