### PR TITLE
fix some permissions in a few rust repos

### DIFF
--- a/github/ipld.yml
+++ b/github/ipld.yml
@@ -1261,12 +1261,6 @@ repositories:
     advanced_security: false
     allow_update_branch: false
     archived: false
-    collaborators:
-      admin:
-        - Stebalien
-      push:
-        - dvc94ch
-        - molekilla
     default_branch: master
     description: Rust IPLD library
     files:
@@ -1306,9 +1300,6 @@ repositories:
     advanced_security: false
     allow_update_branch: false
     archived: false
-    collaborators:
-      push:
-        - vmx
     default_branch: main
     description: This crate provides core types for interoperating with IPLD.
     has_discussions: false
@@ -1321,15 +1312,13 @@ repositories:
     teams:
       pull:
         - github-mgmt stewards
+      push:
         - Rust Team
     visibility: public
   rust-ipld-dagpb:
     advanced_security: false
     allow_update_branch: false
     archived: false
-    collaborators:
-      push:
-        - vmx
     default_branch: main
     description: IPLD DAG-PB codec.
     has_discussions: false
@@ -1342,6 +1331,7 @@ repositories:
     teams:
       pull:
         - github-mgmt stewards
+      push:
         - Rust Team
     visibility: public
   rust-ipld-extract-links:
@@ -1372,9 +1362,6 @@ repositories:
     advanced_security: false
     allow_update_branch: false
     archived: false
-    collaborators:
-      push:
-        - vmx
     default_branch: main
     description: IPLD DAG-JSON support for Serde.
     has_discussions: false
@@ -1387,6 +1374,7 @@ repositories:
     teams:
       pull:
         - github-mgmt stewards
+      push:
         - Rust Team
     visibility: public
   specs:


### PR DESCRIPTION
### Summary
<!-- include a short summary of the request -->

The permissions here look like they're generally a mess, but this should make the situation a little better. This generally:

1. Grants push access to rust repos to the rust team.
2. Removes some special cases that should no longer be necessary.

### Why do you need this?
<!-- include information here which is helpful toward engineers making independent decisions without stakeholders. simple requests may ignore this section, but more complex request should consider what might need to be known in advance and add it -->

I need to be able to push to some rust repos and am on the rust team.

### What else do we need to know?
<!-- any details required to complete the request? are there any special concerns to consider? priority, confidentiality, deadlines, etc -->

**DRI:** @biglep

(because I can't merge this)

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request