### PR TITLE
Unarchive py-cid (no changes)

### DIFF
--- a/github/ipld.yml
+++ b/github/ipld.yml
@@ -1326,7 +1326,38 @@ repositories:
   persistent-metadata:
     archived: true
   py-cid:
+    advanced_security: false
+    allow_update_branch: false
     archived: false
+    collaborators:
+      admin:
+        - dhruvbaldawa
+      push:
+        - web3-bot
+    default_branch: master
+    description: Self-describing content-addressed identifiers for distributed systems implementation in Python
+    has_discussions: false
+    merge_commit_message: PR_TITLE
+    merge_commit_title: MERGE_MESSAGE
+    secret_scanning_push_protection: false
+    secret_scanning: false
+    squash_merge_commit_message: COMMIT_MESSAGES
+    squash_merge_commit_title: COMMIT_OR_PR_TITLE
+    teams:
+      admin:
+        - Admin
+        - ipdx
+        - w3dt-stewards
+      pull:
+        - Core
+        - github-mgmt stewards
+      push:
+        - Python Team
+    topics:
+      - cid
+      - ipld
+      - python
+    visibility: public
   py-ipld-dag:
     archived: true
   react-ipld:


### PR DESCRIPTION
This PR is an addition to https://github.com/ipld/github-mgmt/pull/102

It unarchives `py-cid` repo without making any other changes.